### PR TITLE
Migration for score commit column

### DIFF
--- a/migrations/20200605172945_add_commit_score_column.ts
+++ b/migrations/20200605172945_add_commit_score_column.ts
@@ -1,0 +1,13 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table("commit", (builder) => {
+    builder.integer("score").notNullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table("commit", (builder) => {
+    builder.dropColumn("score");
+  });
+}

--- a/migrations/20200605172945_add_commit_score_column.ts
+++ b/migrations/20200605172945_add_commit_score_column.ts
@@ -2,7 +2,7 @@ import * as Knex from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.table("commit", (builder) => {
-    builder.integer("score").notNullable();
+    builder.integer("score").notNullable().defaultTo(0);
   });
 }
 


### PR DESCRIPTION
Scores are going to be calculated when the Github Bot webhook is triggered and stored in DB.