### PR TITLE
Add sample config file

### DIFF
--- a/docs/.gitlintrc.example
+++ b/docs/.gitlintrc.example
@@ -1,0 +1,10 @@
+preset: default # optional, defaults to "default" preset
+rules:
+	subject-no-trailing-whitespace: 
+		- never # rule condition, is never used
+	body-max-line-length:
+		- always # rule condition, always used for commits from this repo
+		- 100 # rule option, can be any value
+	subject-max-length:
+		- always
+		- 100

--- a/docs/.gitlintrc.example
+++ b/docs/.gitlintrc.example
@@ -1,10 +1,12 @@
 preset: default # optional, defaults to "default" preset
 rules:
 	subject-no-trailing-whitespace: 
-		- never # rule condition, is never used
+		- off # disables the rule (can be on/off)
 	body-max-line-length:
-		- always # rule condition, always used for commits from this repo
-		- 100 # rule option, can be any value
+		- on 
+		- 10  # violation score
+		- 100 # rule argument, can be any value
 	subject-max-length:
-		- always
+		- off
+		- null # uses default rule score
 		- 100

--- a/docs/config.md
+++ b/docs/config.md
@@ -31,9 +31,9 @@ Here is the type definition for `RuleConfig`:
 ```typescript
 type RuleLevel = "on" | "off";
 type RuleScore = number | null;
-type RuleArgs = any;
+type RuleArgs = any[];
 
-type RuleConfig = [RuleLevel?, RuleScore?, RuleArgs?];
+type RuleConfig = [RuleLevel, RuleScore?, ...RuleArgs];
 ```
 
 - `RuleLevel`: Enables the rule when set to "on", otherwise disables it.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,41 @@
+# Configuring gitlint-bot
+
+gitlint-bot lets you control the rules used to analyze commit messages via a configuration file.
+
+## Configuration File
+
+gitlint-bot expects configuration files to be written in YAML with a filename of `.gitlintrc`.
+
+Look at [.gitlintrc.example](./.gitlintrc.example) for an example config file.
+
+### preset
+
+Specifies the rule preset to use.
+
+**Type:** `string`
+
+**Options:** `default`
+
+**Default:** `default`
+
+### rules
+
+Mapping of rule-names to rule configurations.
+
+**Type:** `Record<string, RuleConfig>`
+
+**Default:** `{}`
+
+Here is the type definition for `RuleConfig`:
+
+```typescript
+type RuleLevel = "on" | "off";
+type RuleScore = number | null;
+type RuleArgs = any;
+
+type RuleConfig = [RuleLevel, RuleScore, RuleArgs];
+```
+
+- `RuleLevel`: Enables the rule when set to "on", otherwise disables it.
+- `RuleScore`: Sets the rule violation score when a number is passed. Uses the default rule score when omitted or if `null` is passed.
+- `RuleArgs`: Arguments used to customize the rule.

--- a/docs/config.md
+++ b/docs/config.md
@@ -33,7 +33,7 @@ type RuleLevel = "on" | "off";
 type RuleScore = number | null;
 type RuleArgs = any;
 
-type RuleConfig = [RuleLevel, RuleScore, RuleArgs];
+type RuleConfig = [RuleLevel?, RuleScore?, RuleArgs?];
 ```
 
 - `RuleLevel`: Enables the rule when set to "on", otherwise disables it.

--- a/docs/config.md
+++ b/docs/config.md
@@ -4,7 +4,7 @@ gitlint-bot lets you control the rules used to analyze commit messages via a con
 
 ## Configuration File
 
-gitlint-bot expects configuration files to be written in YAML with a filename of `.gitlintrc`.
+gitlint-bot expects configuration files to be written in YAML with a filename of `.gitlintrc`, `.gitlintrc.yaml` or `gitlintrc.yml`.
 
 Look at [.gitlintrc.example](./.gitlintrc.example) for an example config file.
 
@@ -37,5 +37,5 @@ type RuleConfig = [RuleLevel, RuleScore?, ...RuleArgs];
 ```
 
 - `RuleLevel`: Enables the rule when set to "on", otherwise disables it.
-- `RuleScore`: Sets the rule violation score when a number is passed. Uses the default rule score when omitted or if `null` is passed.
+- `RuleScore`: Sets the rule violation score when a number is passed. Uses the default score defined for the rule when omitted or if `null` is passed.
 - `RuleArgs`: Arguments used to customize the rule.


### PR DESCRIPTION
As part of the configuration, rule options should also be configurable (i.e. the max length value of the `subject-max-length` rule)

Proposed file patterns for config file:
- `.gitlintrc`
- `.gitlintrc.yaml` and `.gitlintrc.yml`