### PR TITLE
Add space before rulename in commit summary msg

### DIFF
--- a/src/slack/sections/topCommits.ts
+++ b/src/slack/sections/topCommits.ts
@@ -17,7 +17,7 @@ export async function createTopCommitsSection(
           `• <${commit.url}|${commit.repo_name}@${shortId}> | \`${subjectLine}\``,
         ];
         commit.diagnoses.forEach((diagnosis) => {
-          messageComponents.push(`\t•${diagnosis.rule}`);
+          messageComponents.push(`\t• ${diagnosis.rule}`);
         });
         return messageComponents.join("\n");
       })


### PR DESCRIPTION
Just a minor style nitpick in the commit summary message.